### PR TITLE
Fix timer reset when game not started

### DIFF
--- a/js/frontend.js
+++ b/js/frontend.js
@@ -49,7 +49,8 @@ document.addEventListener("DOMContentLoaded", async () => {
       document.getElementById("count").textContent = `Your Current Count : ${count}`;
       
       if ((wordList.length > 0 && Number(count) >= number_of_steps) ||
-        (wordList.length > 0 && tempCurrentWord === word_end) || (remainingTime < 1)) {
+        (wordList.length > 0 && tempCurrentWord === word_end) ||
+        (remainingTime !== null && remainingTime < 1)) {
         document.getElementById("catch").removeAttribute("disabled");
         document.getElementById("second").removeAttribute("disabled");
         document.getElementById("url").removeAttribute("disabled");


### PR DESCRIPTION
## Summary
- guard the timer expiration check so the game does not reset before a countdown is configured

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7ce8474e0832ebc44e2756957ab2a