### PR TITLE
Fix toggle highlight reset for issue 12

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -1,30 +1,119 @@
 // content.js
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.action === "switchDomEffect") {
-    // EXPLAIN:DOMの読み込みが行われるごとに、background.jsにポップアップを自動で開くメッセージを送信する。
-    if(!message.enabled) {
-      //MEMO: storage apiで今の真偽値情報を格納する。（commitのとき削除）
-      // ifelseでsetしている真偽値情報を張り替える
+    if (!message.enabled) {
       chrome.runtime.sendMessage({ action: "open_popup" });
-      
-      // EXPLAIN:クリック可能なリンクをハイライト処理
-      const enableClickLinks = document.querySelectorAll("a[href^='/wiki/']");
-      enableClickLinks.forEach(includeLink => {
-        includeLink.style.backgroundColor = "yellow";
-        includeLink.style.borderWidth = "1px";
-        includeLink.style.borderStyle = "dotted";
-        includeLink.style.borderColor = "black";
-      });
-      
-      // EXPLAIN:指定リンク以外を背景色を黒くして除外処理
-      document.querySelectorAll("a[href]:not(a[href^='/wiki/'])").forEach(excludeLink => {
-        excludeLink.style.pointerEvents = "none";
-        excludeLink.style.color = "black";
-        excludeLink.parentElement.style.backgroundColor = "black";
-      });
+      applyDomEffect();
+    } else {
+      removeDomEffect();
     }
     sendResponse({ status: "ok" });
   }
 });
+
+function applyDomEffect() {
+  const enableClickLinks = document.querySelectorAll("a[href^='/wiki/']");
+  enableClickLinks.forEach((includeLink) => {
+    if (includeLink.dataset.originalBackgroundColor === undefined) {
+      includeLink.dataset.originalBackgroundColor = includeLink.style.backgroundColor;
+    }
+    if (includeLink.dataset.originalBorderWidth === undefined) {
+      includeLink.dataset.originalBorderWidth = includeLink.style.borderWidth;
+    }
+    if (includeLink.dataset.originalBorderStyle === undefined) {
+      includeLink.dataset.originalBorderStyle = includeLink.style.borderStyle;
+    }
+    if (includeLink.dataset.originalBorderColor === undefined) {
+      includeLink.dataset.originalBorderColor = includeLink.style.borderColor;
+    }
+
+    includeLink.style.backgroundColor = "yellow";
+    includeLink.style.borderWidth = "1px";
+    includeLink.style.borderStyle = "dotted";
+    includeLink.style.borderColor = "black";
+  });
+
+  document
+    .querySelectorAll("a[href]:not(a[href^='/wiki/'])")
+    .forEach((excludeLink) => {
+      if (excludeLink.dataset.originalPointerEvents === undefined) {
+        excludeLink.dataset.originalPointerEvents = excludeLink.style.pointerEvents;
+      }
+      if (excludeLink.dataset.originalColor === undefined) {
+        excludeLink.dataset.originalColor = excludeLink.style.color;
+      }
+
+      if (excludeLink.parentElement) {
+        if (excludeLink.parentElement.dataset.originalBackgroundColor === undefined) {
+          excludeLink.parentElement.dataset.originalBackgroundColor = excludeLink.parentElement.style.backgroundColor;
+        }
+        excludeLink.parentElement.style.backgroundColor = "black";
+      }
+
+      excludeLink.style.pointerEvents = "none";
+      excludeLink.style.color = "black";
+    });
+}
+
+function removeDomEffect() {
+  const enableClickLinks = document.querySelectorAll("a[href^='/wiki/']");
+  enableClickLinks.forEach((includeLink) => {
+    if (includeLink.dataset.originalBackgroundColor !== undefined) {
+      includeLink.style.backgroundColor = includeLink.dataset.originalBackgroundColor;
+      delete includeLink.dataset.originalBackgroundColor;
+    } else {
+      includeLink.style.backgroundColor = "";
+    }
+
+    if (includeLink.dataset.originalBorderWidth !== undefined) {
+      includeLink.style.borderWidth = includeLink.dataset.originalBorderWidth;
+      delete includeLink.dataset.originalBorderWidth;
+    } else {
+      includeLink.style.borderWidth = "";
+    }
+
+    if (includeLink.dataset.originalBorderStyle !== undefined) {
+      includeLink.style.borderStyle = includeLink.dataset.originalBorderStyle;
+      delete includeLink.dataset.originalBorderStyle;
+    } else {
+      includeLink.style.borderStyle = "";
+    }
+
+    if (includeLink.dataset.originalBorderColor !== undefined) {
+      includeLink.style.borderColor = includeLink.dataset.originalBorderColor;
+      delete includeLink.dataset.originalBorderColor;
+    } else {
+      includeLink.style.borderColor = "";
+    }
+  });
+
+  document
+    .querySelectorAll("a[href]:not(a[href^='/wiki/'])")
+    .forEach((excludeLink) => {
+      if (excludeLink.dataset.originalPointerEvents !== undefined) {
+        excludeLink.style.pointerEvents = excludeLink.dataset.originalPointerEvents;
+        delete excludeLink.dataset.originalPointerEvents;
+      } else {
+        excludeLink.style.pointerEvents = "";
+      }
+
+      if (excludeLink.dataset.originalColor !== undefined) {
+        excludeLink.style.color = excludeLink.dataset.originalColor;
+        delete excludeLink.dataset.originalColor;
+      } else {
+        excludeLink.style.color = "";
+      }
+
+      const parentElement = excludeLink.parentElement;
+      if (parentElement) {
+        if (parentElement.dataset.originalBackgroundColor !== undefined) {
+          parentElement.style.backgroundColor = parentElement.dataset.originalBackgroundColor;
+          delete parentElement.dataset.originalBackgroundColor;
+        } else {
+          parentElement.style.backgroundColor = "";
+        }
+      }
+    });
+}
 
 


### PR DESCRIPTION
## Summary
- ensure the Function Toggle checkbox can both apply and remove the DOM highlighting effect
- restore original link and parent styles when the highlight is disabled to avoid lingering inline styles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8e345e904832ea27c772ce2a6ef9b