### PR TITLE
Reset custom end word and timer preferences after each game

### DIFF
--- a/js/frontend.js
+++ b/js/frontend.js
@@ -507,6 +507,37 @@ document.getElementById("catch").addEventListener("click", async () => {
     });
 
     const timerSeconds = selectedSecondOption ? Number(selectedSecondOption) : 60;
+
+    const resetTargets = [];
+    if (selectedURLOption) {
+      resetTargets.push("selectedURLOption");
+    }
+    if (selectedSecondOption) {
+      resetTargets.push("selectedSecondOption");
+    }
+
+    if (resetTargets.length > 0) {
+      try {
+        await chrome.storage.local.remove(resetTargets);
+      } catch (error) {
+        if (chrome.runtime?.lastError) {
+          console.error("Failed to reset local game options", chrome.runtime.lastError);
+        } else {
+          console.error("Failed to reset local game options", error);
+        }
+      }
+    }
+
+    const urlInput = document.getElementById("url");
+    if (urlInput) {
+      urlInput.value = "";
+    }
+
+    const secondSelect = document.getElementById("second");
+    if (secondSelect) {
+      secondSelect.value = "60";
+    }
+
     timer(timerSeconds);
     document.getElementById("remaining-time").textContent = `time limit : ${timerSeconds} sec`;
 


### PR DESCRIPTION
## Summary
- clear any locally stored end-word and timer selections once a new game begins
- reset the related input fields to their default values so a fresh game starts with the standard settings
- add error handling while removing the stored options

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e9ca61800c832ebe6ffa2eb4e4b629